### PR TITLE
Added another service for testing emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ VML and CSS.
 - [Grunt Litmus](https://www.npmjs.com/package/grunt-litmus) - Send email tests to Litmus with grunt
 - [Gulp Litmus](https://www.npmjs.com/package/gulp-litmus) - Send email tests to Litmus with gulp
 - [SPAM mailtester](http://www.mail-tester.com/) - Test the Spammyness of your Emails
+- [MailTrap](https://mailtrap.io) - A Fake SMTP Server to Test, View and Share emails without spamming real customers.
 
 ## Learning
 - [Responsive HTML Email Design](https://frontendmasters.com/courses/responsive-email/) - Responsive email course by Justine Jand and Jason Rodriguez. They both work at Litmus.


### PR DESCRIPTION
Added Mailtrap - Mailtrap is a fake SMTP server for development teams to test, view and share emails sent from the development and staging environments without spamming real customers