### PR TITLE
Remove resource in Inspirations - Mailchimp Inspiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@
 - [Really good emails](http://reallygoodemails.com/) - The Best Email Designs in the Universe.
 - [Milled](http://milled.com/)
 - [The Top Email Campaigns](https://www.campaignmonitor.com/best-email-marketing-campaigns/) -The most effective email marketing campaigns from Campaign Monitor.
-- [Mailchimp Inspiration](http://inspiration.mailchimp.com/#all) - Mailchimp beautiful newsletters examples.
 - [Htmlemaildesigns](http://htmlemaildesigns.com/) - Beautiful emails to help inspire your next email design.
 
 ## Statistics


### PR DESCRIPTION
https://inspiration.mailchimp.com is no longer maintained or even active. Permanent 301 to their email templates page.